### PR TITLE
docs(api): Add global/user scope to parameters, add app id auth

### DIFF
--- a/docs/ABC-DPT.v1.yaml
+++ b/docs/ABC-DPT.v1.yaml
@@ -307,8 +307,17 @@ paths:
                   value:
                     data:
                       - type: parameter
+                        id: movements
+                        attributes:
+                          scope: user
+                          value: 7
+                          rate: 0.1
+                          min: 0
+                          max: 99999
+                      - type: parameter
                         id: energy
                         attributes:
+                          scope: global
                           value: 82
                           rate: -0.0001
                           min: 0
@@ -316,6 +325,7 @@ paths:
                       - type: parameter
                         id: food
                         attributes:
+                          scope: global
                           value: 27
                           rate: -0.0001
                           min: 0
@@ -323,6 +333,7 @@ paths:
                       - type: parameter
                         id: hygiene
                         attributes:
+                          scope: global
                           value: 7
                           rate: 0
                           min: 0
@@ -330,6 +341,7 @@ paths:
                       - type: parameter
                         id: moral
                         attributes:
+                          scope: global
                           value: 7
                           rate: 0
                           min: 0
@@ -544,10 +556,20 @@ components:
       title: Parameter
       type: object
       x-examples:
+        movements:
+          type: parameter
+          id: movements
+          attributes:
+            scope: user
+            value: 7
+            rate: 0.1
+            min: 0
+            max: 99999
         energy:
           type: parameter
           id: energy
           attributes:
+            scope: global
             value: 82
             rate: -0.0001
             min: 0
@@ -556,6 +578,7 @@ components:
           type: parameter
           id: food
           attributes:
+            scope: global
             value: 27
             rate: -0.0001
             min: 0
@@ -564,6 +587,7 @@ components:
           type: parameter
           id: hygiene
           attributes:
+            scope: global
             value: 7
             rate: 0
             min: 0
@@ -572,6 +596,7 @@ components:
           type: parameter
           id: moral
           attributes:
+            scope: global
             value: 7
             rate: 0
             min: 0
@@ -586,6 +611,7 @@ components:
         id:
           type: string
           enum:
+            - movements
             - energy
             - food
             - hygiene
@@ -593,11 +619,17 @@ components:
         attributes:
           type: object
           required:
+            - scope
             - value
             - rate
             - min
             - max
           properties:
+            scope:
+              type: string
+              enum:
+                - global
+                - user
             value:
               type: number
             rate:
@@ -610,6 +642,13 @@ components:
         - type
         - id
         - attributes
+  securitySchemes:
+    App Instance ID:
+      type: http
+      scheme: bearer
+      description: Each app instance creates a unique ID during onboarding which is sent along every API request to track individual game parameters.
 tags:
   - name: App
     description: API endpoints used by the client app
+security:
+  - App Instance ID: []


### PR DESCRIPTION
Wie besprochen sollen die Spieler\*innenspezifischen Spiel-Parameter auch serverseitig erfasst werden. Dieser PR erweitert daher die OpenAPI-Spezifikation um folgende Features:

1. Jede App-Instanz erzeugt beim ersten Start selber eine Unique ID. Diese wird bei jedem API-Request als HTTP Bearer Auth-Header mit übertragen, also z.B. `Authorization: Bearer uMuvmUUL6NdA0kjkW0trg`
2. Jeder `Parameter` hat jetzt ein `scope`-Attribut, welches angibt, ob der Parameter global oder nur für den User ist

Macht das Sinn? Zwar ist eine UID nicht so richtig ein Bearer-Token und da alle Parameter in einer Liste stattfinden muss diese clientseitig in zwei Listen für global und lokal aufgeteilt werden, dafür passt es ansonsten sehr gut in das Schema der API, finde ich.